### PR TITLE
fix SELinux permissions and file access errors for ~/.llama

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ run_mcp:
 	uvicorn mcp_execute:app --host 0.0.0.0 --port 9002
 
 setup_local:
+	mkdir -p ~/.llama
 	ollama run llama3.2:3b-instruct-fp16 --keepalive 160m &
 	podman run -it -p 8321:8321 -v ~/.llama:/root/.llama:Z llamastack/distribution-ollama:0.2.9 \
 	--port 8321 \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ run_mcp:
 
 setup_local:
 	ollama run llama3.2:3b-instruct-fp16 --keepalive 160m &
-	podman run -it -p 8321:8321 -v ~/.llama:/root/.llama llamastack/distribution-ollama:0.2.9 \
+	podman run -it -p 8321:8321 -v ~/.llama:/root/.llama:Z llamastack/distribution-ollama:0.2.9 \
 	--port 8321 \
 	--env INFERENCE_MODEL="llama3.2:3b-instruct-fp16" \
 	--env OLLAMA_URL=http://host.containers.internal:11434


### PR DESCRIPTION
This ensures that the permissions are set correctly with SELinux to allow a container to access a folder in the home directory

This was done based on the advice of Gemini.

This PR additionally adds a `mkdir` command to the `setup_local` part of the `Makefile` to ensure the directory exists (it may not for people on new installs)