### PR TITLE
Properly register MCP tools

### DIFF
--- a/register_mcp.py
+++ b/register_mcp.py
@@ -9,6 +9,10 @@ load_dotenv()
 base_url = os.getenv("BASE_URL", "http://localhost:8321")
 client = LlamaStackClient(base_url = base_url)
 
+for tool in client.toolgroups.list():
+    if "builtin" not in tool.identifier:
+        client.toolgroups.unregister(toolgroup_id=tool.identifier)
+        print(f"unregistered {tool.identifier}")
 
 
 

--- a/register_mcp.py
+++ b/register_mcp.py
@@ -9,21 +9,9 @@ load_dotenv()
 base_url = os.getenv("BASE_URL", "http://localhost:8321")
 client = LlamaStackClient(base_url = base_url)
 
-client.toolgroups.register(
-    toolgroup_id="mcp::postgres",
-    provider_id="model-context-protocol",
-    mcp_endpoint={"uri": os.getenv("POSTGRES_MCP_URI")},
-)
 
-print("✅ Registered mcp::postgres via host.containers.internal:8000")
 
-client.toolgroups.register(
-    toolgroup_id="mcp::sql",
-    provider_id="model-context-protocol",
-    mcp_endpoint={"uri": os.getenv("SQL_MCP_URI")},
-)
 
-print("✅ Registered custom MCP toolgroup at port 9001")
 
 client.toolgroups.register(
     toolgroup_id="mcp::execute",

--- a/register_mcp.py
+++ b/register_mcp.py
@@ -22,10 +22,12 @@ for replace_tool_id in tools_to_replace:
     client.toolgroups.unregister(toolgroup_id=replace_tool_id)
     print(f"Unregistered old tool {replace_tool_id}")
 
-client.toolgroups.register(
-    toolgroup_id="mcp::execute",
-    provider_id="model-context-protocol",
-    mcp_endpoint={"uri": os.getenv("EXECUTE_MCP_URI")},
-)
 
-print("✅ Registered custom MCP toolgroup at port 9002")
+for tool_id, tool_url in custom_tools.items():
+    client.toolgroups.register(
+        toolgroup_id=tool_id,
+        provider_id="model-context-protocol",
+        mcp_endpoint={"uri": tool_url},
+    )
+
+    print(f"✅ Registered custom MCP toolgroup {tool_id} at {tool_url}")

--- a/register_mcp.py
+++ b/register_mcp.py
@@ -9,13 +9,18 @@ load_dotenv()
 base_url = os.getenv("BASE_URL", "http://localhost:8321")
 client = LlamaStackClient(base_url = base_url)
 
-for tool in client.toolgroups.list():
-    if "builtin" not in tool.identifier:
-        client.toolgroups.unregister(toolgroup_id=tool.identifier)
-        print(f"unregistered {tool.identifier}")
+custom_tools = {
+    "mcp::execute": os.getenv("EXECUTE_MCP_URI")
+}
 
 
+existing_tool_identifiers = list(map(lambda t: t.identifier, client.toolgroups.list()))
+new_tool_identifiers = custom_tools.keys()
 
+tools_to_replace = set(existing_tool_identifiers).intersection(set(new_tool_identifiers))
+for replace_tool_id in tools_to_replace:
+    client.toolgroups.unregister(toolgroup_id=replace_tool_id)
+    print(f"Unregistered old tool {replace_tool_id}")
 
 client.toolgroups.register(
     toolgroup_id="mcp::execute",


### PR DESCRIPTION
When getting set up for the first time, i ran `register_mcp.py` without changing the default environment variables.

Doing so caused tools to be registered with placeholders in the URLs (which wouldn't work and were giving me 500 Server errors in Streamlit). While I won't post the whole stacktrace, the key parts are: `exceptiongroup.ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)` with the underlying exception `httpcore.ConnectError: [Errno -2] Name or service not known`.

I was able to fix this by ensuring that the MCP tasks are properly re-registered each time the script is run (like i was assuming would happen). This is accomplished by unregistering the tools first to ensure that they are added with the most up-to-date URL.